### PR TITLE
Don't exclude specs from coverage

### DIFF
--- a/spec/flame/r18n/locale_in_path_spec.rb
+++ b/spec/flame/r18n/locale_in_path_spec.rb
@@ -18,7 +18,7 @@ describe Flame::R18n::LocaleInPath do
 	let(:example_controller) do
 		Class.new(site_controller) do
 			def index
-				'index of site'
+				# 'index of site'
 			end
 
 			def foo(_arg = nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start do
-	add_filter '/spec/'
-end
 SimpleCov.start
 
 if ENV['CODECOV_TOKEN']


### PR DESCRIPTION
If we'll have unused code in specs — we should know about it.