### PR TITLE
Improve Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,10 +8,22 @@ bundle_cache: &bundle_cache
       - cat *.gemspec
   install_script: bundle update
 
+rubocop_task:
+  container:
+    image: ruby:latest
+  <<: *bundle_cache
+  rubocop_script: bundle exec rubocop
+  only_if: ($CIRRUS_BRANCH == 'master') ||
+    changesInclude(
+      '.cirrus.yml', 'Gemfile', 'Rakefile', '.rubocop.yml', '*.gemspec',
+      '**/*.rb', '**/*.ru'
+    )
+
 test_task:
+  depends_on:
+    - rubocop
   container:
     matrix:
-      image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
       image: ruby:2.7
@@ -19,9 +31,8 @@ test_task:
   environment:
     CODECOV_TOKEN: ENCRYPTED[cdad391413f3dda9fa77999200291c100829553d0ecf1b27ee4eb66affdb01f8eb8f0a3780c1ae3d3ac955c0d6bbe172]
   test_script: bundle exec rake
-
-rubocop_task:
-  container:
-    image: ruby:2.7
-  <<: *bundle_cache
-  rubocop_script: bundle exec rubocop
+  only_if: ($CIRRUS_BRANCH == 'master') ||
+    changesInclude(
+      '.cirrus.yml', 'Gemfile', 'Rakefile', '.rspec', '*.gemspec',
+      '**/*.rb', '**/*.ru', '**/*.yml', '**/*.yaml'
+    )

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,8 +25,9 @@ RSpec/NestedGroups:
   Max: 5
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - '*.gemspec'

--- a/flame-r18n.gemspec
+++ b/flame-r18n.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
 	s.homepage    = 'https://github.com/AlexWayfer/flame-r18n'
 	s.license     = 'MIT'
 
+	s.required_ruby_version = '~> 2.5'
+
 	s.add_dependency 'flame', '>= 5.0.0.rc3', '< 6'
 	s.add_dependency 'r18n-core', '~> 4.0'
 


### PR DESCRIPTION
* Add `depends_on` for test task, run only after lint task.
* Add `only_if`, run tasks only when needed.
* Always use the latest Ruby image for linting.
* Drop Ruby 2.4 support, Flame requires 2.5.